### PR TITLE
Fix #1 issue: product 'SPMUtility' not found

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "cbeacon",
     dependencies: [
-        .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.3.0")
+        .package(url: "https://github.com/apple/swift-package-manager.git", .exact( "0.4.0")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
SPMUtility has been removed from recent version of Swift Package Manager.